### PR TITLE
support for XDG_CONFIG_HOME and XDG_CACHE_HOME variables

### DIFF
--- a/src/fr24/__init__.py
+++ b/src/fr24/__init__.py
@@ -1,8 +1,14 @@
+import os
 from pathlib import Path
 
 from appdirs import user_cache_dir, user_config_dir
 
 PATH_CACHE = Path(user_cache_dir("fr24"))
+if cache_path := os.environ.get("XDG_CACHE_HOME"):
+    PATH_CACHE = Path(cache_path) / "fr24"
+
 PATH_CONFIG = Path(user_config_dir("fr24"))
+if config_path := os.environ.get("XDG_CONFIG_HOME"):
+    PATH_CONFIG = Path(config_path) / "fr24"
 
 FP_CONFIG_FILE = PATH_CONFIG / "fr24.conf"


### PR DESCRIPTION
In MacOS, configurations files tend to go by default to `~/Library/Application Support/` but many prefer them to go to folders similar to those on Linux.
This is usually done with the `XDG_CONFIG_HOME` environment variable.